### PR TITLE
brew: The `devel` section needs a version to work

### DIFF
--- a/etc/wpantund.rb
+++ b/etc/wpantund.rb
@@ -27,6 +27,7 @@ class Wpantund < Formula
 
   devel do
     url 'https://github.com/openthread/wpantund.git', :using => :git, :tag => 'full/latest-unstable'
+    version 'latest-unstable'
   end
 
   depends_on 'pkg-config' => :build


### PR DESCRIPTION
Without this change, attempting to do a `brew install` fails with the following error:

```
Error: Version value must be a string; got a NilClass
```
